### PR TITLE
Remove 'fs' and 'path' dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,9 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "deep-extend": "^0.4.1",
-    "fs": "0.0.2",
     "inquirer": "^1.0.2",
     "lodash": "^4.13.1",
     "mkdirp": "^0.5.1",
-    "path": "^0.12.7",
     "walk-sync": "^0.2.6",
     "yeoman-generator": "0.22.0",
     "yosay": "^1.0.0"


### PR DESCRIPTION
Ref: https://www.npmjs.com/package/fs

Both `fs` and `path` are native Node.js modules and you almost certainly don't want/need them via npm.
